### PR TITLE
my-xm + parameters in camel casing

### DIFF
--- a/Sitecore 8.2.1/my-xm/README.md
+++ b/Sitecore 8.2.1/my-xm/README.md
@@ -1,0 +1,30 @@
+# Sitecore XM Environment
+
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FSitecore%2Fsitecore-azure-quickstart-templates%2Fmaster%2FSitecore%208.2.1%2Fxm%2Fazuredeploy.json%3Ftoken=AVW1Ug5RN1ZFpjUwqAajiNyO-D8COvpzks5YL89jwA%3D%3D" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+This template creates a Sitecore XM Environment with all resources necessary to run Sitecore.
+
+Resources provisioned:
+ 
+  * Azure SQL databases : core, master, web
+  * Azure Search Service for content search
+  * Azure Redis Cache for session state
+  * Application Insights for diagnostics and monitoring
+  * 2 Sitecore roles: Content Delivery, Content Management
+
+    * Hosting plans: one per role
+    * Preconfigured Web Applications, based on the provided WebDeploy packages
+    
+## Parameters
+The **deploymentId** and **licenseXml** parameters are filled in by the PowerShell script.
+
+| Parameter               | Description
+--------------------------|------------------------------------------------
+| sqlserver.login         | The name of the administrator account for the newly created Azure SQL server.
+| sqlserver.password      | The password for the administrator account for Azure SQL server.
+| sitecore.admin.password | The new password for the Sitecore **admin** account.
+| cm.msdeploy.packageurl  | The blob storage url to a Sitecore XM Content Management Web Deploy package.
+| cd.msdeploy.packageurl  | The blob storage url to a Sitecore XM Content Delivery Web Deploy package.
+

--- a/Sitecore 8.2.1/my-xm/README.md
+++ b/Sitecore 8.2.1/my-xm/README.md
@@ -22,9 +22,8 @@ The **deploymentId** and **licenseXml** parameters are filled in by the PowerShe
 
 | Parameter               | Description
 --------------------------|------------------------------------------------
-| sqlserver.login         | The name of the administrator account for the newly created Azure SQL server.
-| sqlserver.password      | The password for the administrator account for Azure SQL server.
-| sitecore.admin.password | The new password for the Sitecore **admin** account.
-| cm.msdeploy.packageurl  | The blob storage url to a Sitecore XM Content Management Web Deploy package.
-| cd.msdeploy.packageurl  | The blob storage url to a Sitecore XM Content Delivery Web Deploy package.
-
+| sqlserverLogin          | The name of the administrator account for the newly created Azure SQL server.
+| sqlserverPassword       | The password for the administrator account for Azure SQL server.
+| sitecoreAdminPassword   | The new password for the Sitecore **admin** account.
+| cmMsdeployPackageurl    | The blob storage url to a Sitecore XM Content Management Web Deploy package.
+| cdMsdeployPackageurl    | The blob storage url to a Sitecore XM Content Delivery Web Deploy package.

--- a/Sitecore 8.2.1/my-xm/azuredeploy.json
+++ b/Sitecore 8.2.1/my-xm/azuredeploy.json
@@ -1,0 +1,546 @@
+﻿{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0-r220+220.1862ac675e9e45e83a045f452b155c07b0a2a6d1",
+  "variables": {
+    "webApiVersion": "2015-08-01",
+    "dbApiVersion": "2014-04-01-preview",
+    "searchApiVersion": "2015-02-28",
+    "redisApiVersion": "2016-04-01",
+    "appInsightsApiVersion": "2014-08-01",
+    "cmHostingPlanNameTidy": "[toLower(trim(parameters('cm.hostingplan.name')))]",
+    "cdHostingPlanNameTidy": "[toLower(trim(parameters('cd.hostingplan.name')))]",
+    "cmWebAppNameTidy": "[toLower(trim(parameters('cm.webapp.name')))]",
+    "cdWebAppNameTidy": "[toLower(trim(parameters('cd.webapp.name')))]",
+    "dbServerNameTidy": "[toLower(trim(parameters('sqlserver.name')))]",
+    "coreDbNameTidy": "[toLower(trim(parameters('core.sqldatabase.name')))]",
+    "webDbNameTidy": "[toLower(trim(parameters('web.sqldatabase.name')))]",
+    "webDbServerNameTidy": "[toLower(trim(parameters('web.sqlserver.name')))]",
+    "masterDbNameTidy": "[toLower(trim(parameters('master.sqldatabase.name')))]",
+    "searchServiceNameTidy": "[toLower(trim(parameters('searchservice.name')))]",
+    "redisCacheNameTidy": "[toLower(trim(parameters('rediscache.name')))]",
+    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsights.name')))]",
+    "licenseXml": "[parameters('licenseXml')]"
+  },
+  "parameters": {
+    "deploymentId": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().name]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    },
+    "cm.hostingplan.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-cm-hp')]"
+    },
+    "cd.hostingplan.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-cd-hp')]"
+    },
+    "cm.webapp.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-cm')]"
+    },
+    "cd.webapp.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-cd')]"
+    },
+    "cm.msdeploy.packageurl": {
+      "type": "securestring"
+    },
+    "cd.msdeploy.packageurl": {
+      "type": "securestring"
+    },
+    "sqlserver.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-sql')]"
+    },
+    "sqlserver.login": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sqlserver.password": {
+      "type": "securestring",
+      "minLength": 8
+    },
+    "web.sqlserver.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-web-sql')]"
+    },
+    "web.sqlserver.login": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "[parameters('sqlserver.login')]"
+    },
+    "web.sqlserver.password": {
+      "type": "securestring",
+      "minLength": 8,
+      "defaultValue": "[parameters('sqlserver.password')]"
+    },
+    "core.sqldatabase.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-core-db')]"
+    },
+    "master.sqldatabase.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-master-db')]"
+    },
+    "web.sqldatabase.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-web-db')]"
+    },
+    "cm.core.sqldatabase.username": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "[concat('cm-core-', deployment().name, '-user')]"
+    },
+    "cm.core.sqldatabase.password": {
+      "type": "securestring",
+      "minLength": 8,
+      "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+    },
+    "cm.master.sqldatabase.username": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "[concat('cm-master-', deployment().name, '-user')]"
+    },
+    "cm.master.sqldatabase.password": {
+      "type": "securestring",
+      "minLength": 8,
+      "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserver.password')))]"
+    },
+    "cm.web.sqldatabase.username": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "[concat('cm-web-', deployment().name, '-user')]"
+    },
+    "cm.web.sqldatabase.password": {
+      "type": "securestring",
+      "minLength": 8,
+      "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+    },
+    "cd.core.sqldatabase.username": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "[concat('cd-core-', deployment().name, '-user')]"
+    },
+    "cd.core.sqldatabase.password": {
+      "type": "securestring",
+      "minLength": 8,
+      "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+    },
+    "cd.web.sqldatabase.username": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "[concat('cd-web-', deployment().name, '-user')]"
+    },
+    "cd.web.sqldatabase.password": {
+      "type": "securestring",
+      "minLength": 8,
+      "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+    },
+    "searchservice.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
+    },
+    "rediscache.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-redis')]"
+    },
+    "applicationinsights.name": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-ai')]"
+    },
+    "applicationinsights.location": {
+      "type": "string",
+      "defaultValue": "East US",
+      "allowedValues": [ "East US", "South Central US", "North Europe", "West Europe" ]
+    },
+    "cm.hostingplan.skuname": {
+      "type": "string",
+      "defaultValue": "S1"
+    },
+    "cm.hostingplan.skucapacity": {
+      "type": "int",
+      "defaultValue": 1
+    },
+    "cd.hostingplan.skuname": {
+      "type": "string",
+      "defaultValue": "S1"
+    },
+    "cd.hostingplan.skucapacity": {
+      "type": "int",
+      "defaultValue": 1
+    },
+    "searchservice.skuname": {
+      "type": "string",
+      "defaultValue": "Standard"
+    },
+    "sqlserver.version": {
+      "type": "string",
+      "defaultValue": "12.0"
+    },
+    "sqldatabase.collation": {
+      "type": "string",
+      "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
+    },
+    "sqldatabase.edition": {
+      "type": "string",
+      "defaultValue": "Standard"
+    },
+    "sqldatabase.maxsize": {
+      "type": "string",
+      "defaultValue": "10737418240"
+    },
+    "sqldatabase.serviceobjectivelevel": {
+      "type": "string",
+      "defaultValue": "S1"
+    },
+    "searchservice.cdlicacount": {
+      "type": "int",
+      "defaultValue": 1
+    },
+    "searchservice.partitioncount": {
+      "type": "int",
+      "defaultValue": 1
+    },
+    "rediscache.skuname": {
+      "type": "string",
+      "defaultValue": "Basic"
+    },
+    "rediscache.skufamily": {
+      "type": "string",
+      "defaultValue": "C"
+    },
+    "rediscache.skucapacity": {
+      "type": "string",
+      "defaultValue": "0"
+    },
+    "sitecoreTags": {
+      "type": "object",
+      "defaultValue": {
+        "provider": "b51535c2-ab3e-4a68-95f8-e2e3c9a19299"
+      }
+    },
+    "licenseXml": {
+      "type": "securestring"
+    },
+    "security.clientIp": {
+      "type": "string",
+      "defaultValue": "0.0.0.0"
+    },
+    "security.clientIpMask": {
+      "type": "string",
+      "defaultValue": "0.0.0.0"
+    },
+    "sitecore.admin.password": {
+      "type": "securestring",
+      "minLength": 8,
+      "maxLength": 128
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "name": "[variables('cmHostingPlanNameTidy')]",
+      "apiVersion": "[variables('webApiVersion')]",
+      "sku": {
+        "name": "[parameters('cm.hostingplan.skuname')]",
+        "capacity": "[parameters('cm.hostingplan.skucapacity')]"
+      },
+      "properties": {
+        "name": "[variables('cmHostingPlanNameTidy')]"
+      },
+      "location": "[parameters('location')]",
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      }
+    },
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "name": "[variables('cdHostingPlanNameTidy')]",
+      "apiVersion": "[variables('webApiVersion')]",
+      "sku": {
+        "name": "[parameters('cd.hostingplan.skuname')]",
+        "capacity": "[parameters('cd.hostingplan.skucapacity')]"
+      },
+      "properties": {
+        "name": "[variables('cdHostingPlanNameTidy')]"
+      },
+      "location": "[parameters('location')]",
+      "dependsOn": [ "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]" ],
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "name": "[variables('cmWebAppNameTidy')]",
+      "apiVersion": "[variables('webApiVersion')]",
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
+        "siteConfig": {
+          "use32BitWorkerProcess": false,
+          "alwaysOn": true,
+          "phpVersion": "",
+          "defaultDocuments": [
+            "index.html"
+          ]
+        }
+      },
+      "location": "[parameters('location')]",
+      "dependsOn": [ "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]" ],
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      },
+      "resources": [
+        {
+          "name": "MSDeploy",
+          "type": "extensions",
+          "location": "[parameters('location')]",
+          "apiVersion": "[variables('webApiVersion')]",
+          "dependsOn": [ "[concat('Microsoft.Web/sites/', variables('cmWebAppNameTidy'))]", "[resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy'))]", "[resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('coreDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('masterDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]" ],
+          "properties": {
+            "packageUri": "[parameters('cm.msdeploy.packageurl')]",
+            "dbType": "SQL",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "setParameters": {
+              "Application Path": "[variables('cmWebAppNameTidy')]",
+              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
+              "Core DB User Name": "[parameters('cm.core.sqldatabase.username')]",
+              "Core DB Password": "[parameters('cm.core.sqldatabase.password')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cm.core.sqldatabase.username'), ';Password=', parameters('cm.core.sqldatabase.password'), ';')]",
+              "Master DB User Name": "[parameters('cm.master.sqldatabase.username')]",
+              "Master DB Password": "[parameters('cm.master.sqldatabase.password')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cm.master.sqldatabase.username'), ';Password=', parameters('cm.master.sqldatabase.password'), ';')]",
+              "Web DB User Name": "[parameters('cm.web.sqldatabase.username')]",
+              "Web DB Password": "[parameters('cm.web.sqldatabase.password')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cm.web.sqldatabase.username'), ';Password=', parameters('cm.web.sqldatabase.password'), ';')]",
+              "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
+              "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
+              "Application Insights Role": "CM",
+              "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('cmWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
+              "License Xml": "[variables('licenseXml')]",
+              "IP Security Client IP": "[parameters('security.clientIp')]",
+              "IP Security Client IP Mask": "[parameters('security.clientIpMask')]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "name": "[variables('cdWebAppNameTidy')]",
+      "apiVersion": "[variables('webApiVersion')]",
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
+        "siteConfig": {
+          "use32BitWorkerProcess": false,
+          "alwaysOn": true,
+          "phpVersion": "",
+          "defaultDocuments": [
+            "index.html"
+          ]
+        }
+      },
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]"
+      ],
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      },
+      "resources": [
+        {
+          "name": "MSDeploy",
+          "type": "extensions",
+          "location": "[parameters('location')]",
+          "apiVersion": "[variables('webApiVersion')]",
+          "dependsOn": [
+            "[concat('Microsoft.Web/sites/', variables('cdWebAppNameTidy'))]",
+            "[concat('Microsoft.Web/sites/', variables('cmWebAppNameTidy'), '/Extensions/MSDeploy')]",
+            "[resourceId('Microsoft.Cache/Redis', variables('redisCacheNameTidy'))]",
+            "[resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy'))]",
+            "[resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))]",
+            "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('coreDbNameTidy'))]",
+            "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]"
+          ],
+          "properties": {
+            "packageUri": "[parameters('cd.msdeploy.packageurl')]",
+            "dbType": "SQL",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "setParameters": {
+              "Application Path": "[variables('cdWebAppNameTidy')]",
+              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
+              "Core DB User Name": "[parameters('cd.core.sqldatabase.username')]",
+              "Core DB Password": "[parameters('cd.core.sqldatabase.password')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cd.core.sqldatabase.username'), ';Password=', parameters('cd.core.sqldatabase.password'), ';')]",
+              "Web DB User Name": "[parameters('cd.web.sqldatabase.username')]",
+              "Web DB Password": "[parameters('cd.web.sqldatabase.password')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cd.web.sqldatabase.username'), ';Password=', parameters('cd.web.sqldatabase.password'), ';')]",
+              "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
+              "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
+              "Application Insights Role": "CD",
+              "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('cdWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
+              "Redis Connection String": "[concat(reference(variables('redisCacheNameTidy')).hostName, ':', reference(variables('redisCacheNameTidy')).sslPort, ',password=', listKeys(resourceId('Microsoft.Cache/Redis', variables('redisCacheNameTidy')), variables('redisApiVersion')).primaryKey, ',ssl=True,abortConnect=False')]",
+              "License Xml": "[variables('licenseXml')]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "[variables('dbApiVersion')]",
+      "properties": {
+        "administratorLogin": "[parameters('sqlserver.login')]",
+        "administratorLoginPassword": "[parameters('sqlserver.password')]",
+        "version": "[parameters('sqlserver.version')]"
+      },
+      "name": "[variables('dbServerNameTidy')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      },
+      "resources": [
+        {
+          "type": "firewallrules",
+          "apiVersion": "[variables('dbApiVersion')]",
+          "properties": {
+            "endIpAddress": "0.0.0.0",
+            "startIpAddress": "0.0.0.0"
+          },
+          "name": "AllowAllWindowsAzureIps",
+          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]" ]
+        },
+        {
+          "type": "databases",
+          "apiVersion": "[variables('dbApiVersion')]",
+          "properties": {
+            "edition": "[parameters('sqldatabase.edition')]",
+            "collation": "[parameters('sqldatabase.collation')]",
+            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+          },
+          "name": "[variables('coreDbNameTidy')]",
+          "location": "[parameters('location')]",
+          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]" ],
+          "tags": {
+            "provider": "[parameters('sitecoreTags').provider]"
+          }
+        },
+        {
+          "type": "databases",
+          "apiVersion": "[variables('dbApiVersion')]",
+          "properties": {
+            "edition": "[parameters('sqldatabase.edition')]",
+            "collation": "[parameters('sqldatabase.collation')]",
+            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+          },
+          "name": "[variables('masterDbNameTidy')]",
+          "location": "[parameters('location')]",
+          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]" ],
+          "tags": {
+            "provider": "[parameters('sitecoreTags').provider]"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "[variables('dbApiVersion')]",
+      "properties": {
+        "administratorLogin": "[parameters('web.sqlserver.login')]",
+        "administratorLoginPassword": "[parameters('web.sqlserver.password')]",
+        "version": "[parameters('sqlserver.version')]"
+      },
+      "name": "[variables('webDbServerNameTidy')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      },
+      "resources": [
+        {
+          "type": "firewallrules",
+          "apiVersion": "[variables('dbApiVersion')]",
+          "properties": {
+            "endIpAddress": "0.0.0.0",
+            "startIpAddress": "0.0.0.0"
+          },
+          "name": "AllowAllWindowsAzureIps",
+          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('webDbServerNameTidy'))]" ]
+        },
+        {
+          "type": "databases",
+          "apiVersion": "[variables('dbApiVersion')]",
+          "properties": {
+            "edition": "[parameters('sqldatabase.edition')]",
+            "collation": "[parameters('sqldatabase.collation')]",
+            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+          },
+          "name": "[variables('webDbNameTidy')]",
+          "location": "[parameters('location')]",
+          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('webDbServerNameTidy'))]" ],
+          "tags": {
+            "provider": "[parameters('sitecoreTags').provider]"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Search/searchServices",
+      "apiVersion": "[variables('searchApiVersion')]",
+      "name": "[variables('searchServiceNameTidy')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "[toLower(parameters('searchservice.skuname'))]"
+        },
+        "cdlicaCount": "[parameters('searchservice.cdlicacount')]",
+        "partitionCount": "[parameters('searchservice.partitioncount')]"
+      },
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      }
+    },
+    {
+      "type": "Microsoft.Cache/Redis",
+      "name": "[variables('redisCacheNameTidy')]",
+      "apiVersion": "[variables('redisApiVersion')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "[parameters('rediscache.skuname')]",
+          "family": "[parameters('rediscache.skufamily')]",
+          "capacity": "[parameters('rediscache.skucapacity')]"
+        },
+        "enableNonSslPort": false
+      },
+      "dependsOn": [ "[resourceId('Microsoft.Web/sites', variables('cdWebAppNameTidy'))]" ],
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      }
+    },
+    {
+      "type": "Microsoft.Insights/Components",
+      "name": "[variables('appInsightsNameTidy')]",
+      "apiVersion": "[variables('appInsightsApiVersion')]",
+      "location": "[parameters('applicationinsights.location')]",
+      "properties": {
+        "ApplicationId": "[variables('appInsightsNameTidy')]",
+        "Application_Type": "web"
+      },
+      "tags": {
+        "provider": "[parameters('sitecoreTags').provider]"
+      }
+    }
+  ]
+}

--- a/Sitecore 8.2.1/my-xm/azuredeploy.json
+++ b/Sitecore 8.2.1/my-xm/azuredeploy.json
@@ -7,18 +7,18 @@
     "searchApiVersion": "2015-02-28",
     "redisApiVersion": "2016-04-01",
     "appInsightsApiVersion": "2014-08-01",
-    "cmHostingPlanNameTidy": "[toLower(trim(parameters('cm.hostingplan.name')))]",
-    "cdHostingPlanNameTidy": "[toLower(trim(parameters('cd.hostingplan.name')))]",
-    "cmWebAppNameTidy": "[toLower(trim(parameters('cm.webapp.name')))]",
-    "cdWebAppNameTidy": "[toLower(trim(parameters('cd.webapp.name')))]",
-    "dbServerNameTidy": "[toLower(trim(parameters('sqlserver.name')))]",
-    "coreDbNameTidy": "[toLower(trim(parameters('core.sqldatabase.name')))]",
-    "webDbNameTidy": "[toLower(trim(parameters('web.sqldatabase.name')))]",
-    "webDbServerNameTidy": "[toLower(trim(parameters('web.sqlserver.name')))]",
-    "masterDbNameTidy": "[toLower(trim(parameters('master.sqldatabase.name')))]",
-    "searchServiceNameTidy": "[toLower(trim(parameters('searchservice.name')))]",
-    "redisCacheNameTidy": "[toLower(trim(parameters('rediscache.name')))]",
-    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsights.name')))]",
+    "cmHostingPlanNameTidy": "[toLower(trim(parameters('cmHostingplanName')))]",
+    "cdHostingPlanNameTidy": "[toLower(trim(parameters('cdHostingplanName')))]",
+    "cmWebAppNameTidy": "[toLower(trim(parameters('cmWebappName')))]",
+    "cdWebAppNameTidy": "[toLower(trim(parameters('cdWebappName')))]",
+    "dbServerNameTidy": "[toLower(trim(parameters('sqlserverName')))]",
+    "coreDbNameTidy": "[toLower(trim(parameters('coreSqldatabaseName')))]",
+    "webDbNameTidy": "[toLower(trim(parameters('webSqldatabaseName')))]",
+    "webDbServerNameTidy": "[toLower(trim(parameters('webSqlserverName')))]",
+    "masterDbNameTidy": "[toLower(trim(parameters('masterSqldatabaseName')))]",
+    "searchServiceNameTidy": "[toLower(trim(parameters('searchserviceName')))]",
+    "redisCacheNameTidy": "[toLower(trim(parameters('rediscacheName')))]",
+    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsightsName')))]",
     "licenseXml": "[parameters('licenseXml')]"
   },
   "parameters": {
@@ -30,190 +30,195 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "cm.hostingplan.name": {
+    "cmHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cm-hp')]"
     },
-    "cd.hostingplan.name": {
+    "cdHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd-hp')]"
     },
-    "cm.webapp.name": {
+    "cmWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cm')]"
     },
-    "cd.webapp.name": {
+    "cdWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd')]"
     },
-    "cm.msdeploy.packageurl": {
+    "cmMsdeployPackageurl": {
       "type": "securestring"
     },
-    "cd.msdeploy.packageurl": {
+    "cdMsdeployPackageurl": {
       "type": "securestring"
     },
-    "sqlserver.name": {
+    "sqlserverName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-sql')]"
     },
-    "sqlserver.login": {
+    "sqlserverLogin": {
       "type": "string",
       "minLength": 1
     },
-    "sqlserver.password": {
+    "sqlserverPassword": {
       "type": "securestring",
       "minLength": 8
     },
-    "web.sqlserver.name": {
+    "webSqlserverName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-sql')]"
     },
-    "web.sqlserver.login": {
+    "webSqlserverLogin": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "[parameters('sqlserver.login')]"
+      "defaultValue": "[parameters('sqlserverLogin')]"
     },
-    "web.sqlserver.password": {
+    "webSqlserverPassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[parameters('sqlserver.password')]"
+      "defaultValue": "[parameters('sqlserverPassword')]"
     },
-    "core.sqldatabase.name": {
+    "coreSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-core-db')]"
     },
-    "master.sqldatabase.name": {
+    "masterSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-master-db')]"
     },
-    "web.sqldatabase.name": {
+    "webSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-db')]"
     },
-    "cm.core.sqldatabase.username": {
+    "cmCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-core-', deployment().name, '-user')]"
     },
-    "cm.core.sqldatabase.password": {
+    "cmCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cm.master.sqldatabase.username": {
+    "cmMasterSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-master-', deployment().name, '-user')]"
     },
-    "cm.master.sqldatabase.password": {
+    "cmMasterSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cm.web.sqldatabase.username": {
+    "cmWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-web-', deployment().name, '-user')]"
     },
-    "cm.web.sqldatabase.password": {
+    "cmWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cd.core.sqldatabase.username": {
+    "cdCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cd-core-', deployment().name, '-user')]"
     },
-    "cd.core.sqldatabase.password": {
+    "cdCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cd.web.sqldatabase.username": {
+    "cdWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cd-web-', deployment().name, '-user')]"
     },
-    "cd.web.sqldatabase.password": {
+    "cdWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "searchservice.name": {
+    "searchserviceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
     },
-    "rediscache.name": {
+    "rediscacheName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-redis')]"
     },
-    "applicationinsights.name": {
+    "applicationinsightsName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-ai')]"
     },
-    "applicationinsights.location": {
+    "applicationinsightsLocation": {
       "type": "string",
       "defaultValue": "East US",
-      "allowedValues": [ "East US", "South Central US", "North Europe", "West Europe" ]
+      "allowedValues": [
+        "East US",
+        "South Central US",
+        "North Europe",
+        "West Europe"
+      ]
     },
-    "cm.hostingplan.skuname": {
+    "cmHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "cm.hostingplan.skucapacity": {
+    "cmHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
-    "cd.hostingplan.skuname": {
+    "cdHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "cd.hostingplan.skucapacity": {
+    "cdHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
-    "searchservice.skuname": {
+    "searchserviceSkuname": {
       "type": "string",
       "defaultValue": "Standard"
     },
-    "sqlserver.version": {
+    "sqlserverVersion": {
       "type": "string",
       "defaultValue": "12.0"
     },
-    "sqldatabase.collation": {
+    "sqldatabaseCollation": {
       "type": "string",
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
     },
-    "sqldatabase.edition": {
+    "sqldatabaseEdition": {
       "type": "string",
       "defaultValue": "Standard"
     },
-    "sqldatabase.maxsize": {
+    "sqldatabaseMaxsize": {
       "type": "string",
       "defaultValue": "10737418240"
     },
-    "sqldatabase.serviceobjectivelevel": {
+    "sqldatabaseServiceobjectivelevel": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "searchservice.cdlicacount": {
+    "searchserviceCdlicacount": {
       "type": "int",
       "defaultValue": 1
     },
-    "searchservice.partitioncount": {
+    "searchservicePartitioncount": {
       "type": "int",
       "defaultValue": 1
     },
-    "rediscache.skuname": {
+    "rediscacheSkuname": {
       "type": "string",
       "defaultValue": "Basic"
     },
-    "rediscache.skufamily": {
+    "rediscacheSkufamily": {
       "type": "string",
       "defaultValue": "C"
     },
-    "rediscache.skucapacity": {
+    "rediscacheSkucapacity": {
       "type": "string",
       "defaultValue": "0"
     },
@@ -226,15 +231,15 @@
     "licenseXml": {
       "type": "securestring"
     },
-    "security.clientIp": {
+    "securityClientIp": {
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
-    "security.clientIpMask": {
+    "securityClientIpMask": {
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
-    "sitecore.admin.password": {
+    "sitecoreAdminPassword": {
       "type": "securestring",
       "minLength": 8,
       "maxLength": 128
@@ -246,8 +251,8 @@
       "name": "[variables('cmHostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('cm.hostingplan.skuname')]",
-        "capacity": "[parameters('cm.hostingplan.skucapacity')]"
+        "name": "[parameters('cmHostingplanSkuname')]",
+        "capacity": "[parameters('cmHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('cmHostingPlanNameTidy')]"
@@ -262,14 +267,16 @@
       "name": "[variables('cdHostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('cd.hostingplan.skuname')]",
-        "capacity": "[parameters('cd.hostingplan.skucapacity')]"
+        "name": "[parameters('cdHostingplanSkuname')]",
+        "capacity": "[parameters('cdHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('cdHostingPlanNameTidy')]"
       },
       "location": "[parameters('location')]",
-      "dependsOn": [ "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]" ],
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]"
+      ],
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
       }
@@ -290,7 +297,9 @@
         }
       },
       "location": "[parameters('location')]",
-      "dependsOn": [ "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]" ],
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]"
+      ],
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
       },
@@ -300,33 +309,40 @@
           "type": "extensions",
           "location": "[parameters('location')]",
           "apiVersion": "[variables('webApiVersion')]",
-          "dependsOn": [ "[concat('Microsoft.Web/sites/', variables('cmWebAppNameTidy'))]", "[resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy'))]", "[resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('coreDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('masterDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]" ],
+          "dependsOn": [
+            "[concat('Microsoft.Web/sites/', variables('cmWebAppNameTidy'))]",
+            "[resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy'))]",
+            "[resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))]",
+            "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('coreDbNameTidy'))]",
+            "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('masterDbNameTidy'))]",
+            "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]"
+          ],
           "properties": {
-            "packageUri": "[parameters('cm.msdeploy.packageurl')]",
+            "packageUri": "[parameters('cmMsdeployPackageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cmWebAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
-              "Core DB User Name": "[parameters('cm.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('cm.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cm.core.sqldatabase.username'), ';Password=', parameters('cm.core.sqldatabase.password'), ';')]",
-              "Master DB User Name": "[parameters('cm.master.sqldatabase.username')]",
-              "Master DB Password": "[parameters('cm.master.sqldatabase.password')]",
-              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
-              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cm.master.sqldatabase.username'), ';Password=', parameters('cm.master.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('cm.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('cm.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cm.web.sqldatabase.username'), ';Password=', parameters('cm.web.sqldatabase.password'), ';')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
+              "Core DB User Name": "[parameters('cmCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('cmCoreSqldatabasePassword')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cmCoreSqldatabaseUsername'), ';Password=', parameters('cmCoreSqldatabasePassword'), ';')]",
+              "Master DB User Name": "[parameters('cmMasterSqldatabaseUsername')]",
+              "Master DB Password": "[parameters('cmMasterSqldatabasePassword')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cmMasterSqldatabaseUsername'), ';Password=', parameters('cmMasterSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('cmWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('cmWebSqldatabasePassword')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cmWebSqldatabaseUsername'), ';Password=', parameters('cmWebSqldatabasePassword'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
               "Application Insights Role": "CM",
               "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('cmWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
               "License Xml": "[variables('licenseXml')]",
-              "IP Security Client IP": "[parameters('security.clientIp')]",
-              "IP Security Client IP Mask": "[parameters('security.clientIpMask')]"
+              "IP Security Client IP": "[parameters('securityClientIp')]",
+              "IP Security Client IP Mask": "[parameters('securityClientIpMask')]"
             }
           }
         }
@@ -370,20 +386,20 @@
             "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]"
           ],
           "properties": {
-            "packageUri": "[parameters('cd.msdeploy.packageurl')]",
+            "packageUri": "[parameters('cdMsdeployPackageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cdWebAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
-              "Core DB User Name": "[parameters('cd.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('cd.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cd.core.sqldatabase.username'), ';Password=', parameters('cd.core.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('cd.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('cd.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cd.web.sqldatabase.username'), ';Password=', parameters('cd.web.sqldatabase.password'), ';')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
+              "Core DB User Name": "[parameters('cdCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('cdCoreSqldatabasePassword')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cdCoreSqldatabaseUsername'), ';Password=', parameters('cdCoreSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('cdWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('cdWebSqldatabasePassword')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cdWebSqldatabaseUsername'), ';Password=', parameters('cdWebSqldatabasePassword'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
               "Application Insights Role": "CD",
@@ -399,9 +415,9 @@
       "type": "Microsoft.Sql/servers",
       "apiVersion": "[variables('dbApiVersion')]",
       "properties": {
-        "administratorLogin": "[parameters('sqlserver.login')]",
-        "administratorLoginPassword": "[parameters('sqlserver.password')]",
-        "version": "[parameters('sqlserver.version')]"
+        "administratorLogin": "[parameters('sqlserverLogin')]",
+        "administratorLoginPassword": "[parameters('sqlserverPassword')]",
+        "version": "[parameters('sqlserverVersion')]"
       },
       "name": "[variables('dbServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -417,20 +433,24 @@
             "startIpAddress": "0.0.0.0"
           },
           "name": "AllowAllWindowsAzureIps",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]" ]
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]"
+          ]
         },
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('coreDbNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[parameters('sitecoreTags').provider]"
           }
@@ -439,14 +459,16 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('masterDbNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('dbServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[parameters('sitecoreTags').provider]"
           }
@@ -457,9 +479,9 @@
       "type": "Microsoft.Sql/servers",
       "apiVersion": "[variables('dbApiVersion')]",
       "properties": {
-        "administratorLogin": "[parameters('web.sqlserver.login')]",
-        "administratorLoginPassword": "[parameters('web.sqlserver.password')]",
-        "version": "[parameters('sqlserver.version')]"
+        "administratorLogin": "[parameters('webSqlserverLogin')]",
+        "administratorLoginPassword": "[parameters('webSqlserverPassword')]",
+        "version": "[parameters('sqlserverVersion')]"
       },
       "name": "[variables('webDbServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -475,20 +497,24 @@
             "startIpAddress": "0.0.0.0"
           },
           "name": "AllowAllWindowsAzureIps",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('webDbServerNameTidy'))]" ]
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('webDbServerNameTidy'))]"
+          ]
         },
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('webDbNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('webDbServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('webDbServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[parameters('sitecoreTags').provider]"
           }
@@ -502,10 +528,10 @@
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
-          "name": "[toLower(parameters('searchservice.skuname'))]"
+          "name": "[toLower(parameters('searchserviceSkuname'))]"
         },
-        "cdlicaCount": "[parameters('searchservice.cdlicacount')]",
-        "partitionCount": "[parameters('searchservice.partitioncount')]"
+        "cdlicaCount": "[parameters('searchserviceCdlicacount')]",
+        "partitionCount": "[parameters('searchservicePartitioncount')]"
       },
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
@@ -518,13 +544,15 @@
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
-          "name": "[parameters('rediscache.skuname')]",
-          "family": "[parameters('rediscache.skufamily')]",
-          "capacity": "[parameters('rediscache.skucapacity')]"
+          "name": "[parameters('rediscacheSkuname')]",
+          "family": "[parameters('rediscacheSkufamily')]",
+          "capacity": "[parameters('rediscacheSkucapacity')]"
         },
         "enableNonSslPort": false
       },
-      "dependsOn": [ "[resourceId('Microsoft.Web/sites', variables('cdWebAppNameTidy'))]" ],
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', variables('cdWebAppNameTidy'))]"
+      ],
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
       }
@@ -533,7 +561,7 @@
       "type": "Microsoft.Insights/Components",
       "name": "[variables('appInsightsNameTidy')]",
       "apiVersion": "[variables('appInsightsApiVersion')]",
-      "location": "[parameters('applicationinsights.location')]",
+      "location": "[parameters('applicationinsightsLocation')]",
       "properties": {
         "ApplicationId": "[variables('appInsightsNameTidy')]",
         "Application_Type": "web"

--- a/Sitecore 8.2.1/my-xm/azuredeploy.parameters.json
+++ b/Sitecore 8.2.1/my-xm/azuredeploy.parameters.json
@@ -1,0 +1,23 @@
+﻿{
+  "deploymentId": {
+    "value": ""
+  },
+  "sitecore.admin.password": {
+    "value": ""
+  },
+  "sqlserver.login": {
+    "value": ""
+  },
+  "sqlserver.password": {
+    "value": ""
+  },
+  "cm.msdeploy.packageurl": {
+    "value": ""
+  },
+  "cd.msdeploy.packageurl": {
+    "value": ""
+  },
+  "licenseXml": {
+    "value": ""
+  }
+}

--- a/Sitecore 8.2.1/my-xm/azuredeploy.parameters.json
+++ b/Sitecore 8.2.1/my-xm/azuredeploy.parameters.json
@@ -2,19 +2,19 @@
   "deploymentId": {
     "value": ""
   },
-  "sitecore.admin.password": {
+  "sitecoreAdminPassword": {
     "value": ""
   },
-  "sqlserver.login": {
+  "sqlserverLogin": {
     "value": ""
   },
-  "sqlserver.password": {
+  "sqlserverPassword": {
     "value": ""
   },
-  "cm.msdeploy.packageurl": {
+  "cmMsdeployPackageurl": {
     "value": ""
   },
-  "cd.msdeploy.packageurl": {
+  "cdMsdeployPackageurl": {
     "value": ""
   },
   "licenseXml": {


### PR DESCRIPTION
Regarding the issue #4, I would like to propose to rename all the parameters containing 
> .[a-z]

 by 

> .[A-Z] 

More explanation around this approach:
* When we use `New-AzureRmResourceGroupDeployment` with inline parameters like `-sqlserver.login myLogin` we have an error message because of the `.`. I know we could use other alternatives like `-TemplateParameterObject` or `-TemplateParameterFile` like described [here](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-template-deploy#parameters), but could be a limitation.
* Furthermore, [best practices for templates parameters](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-template-best-practices#parameters) indicates: 
> 2. Parameter names should follow camelCasing.