### PR TITLE
Remove extra dependsOn.

### DIFF
--- a/Sitecore 8.2.1/my-xm/azuredeploy.json
+++ b/Sitecore 8.2.1/my-xm/azuredeploy.json
@@ -274,9 +274,6 @@
         "name": "[variables('cdHostingPlanNameTidy')]"
       },
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]"
-      ],
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
       }
@@ -550,9 +547,6 @@
         },
         "enableNonSslPort": false
       },
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', variables('cdWebAppNameTidy'))]"
-      ],
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
       }


### PR DESCRIPTION
It optimizes the duration of the deployment. For example by deploying just the services (without the MSDeploy):
* Before this PR the deployment took ~32min
* After this PR the deployment took ~18min